### PR TITLE
 - default `process.env.NODE_ENV` to `production`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project is following [Semantic Versioning](http://semver.org)
 
 ## [Unreleased][]
 
+## [0.1.11][] - 2018-02-09
+
+ - default `process.env.NODE_ENV` to `production` when packaging the app for distribution with webpack  
+
 ## [0.1.10][] - 2017-12-14
 
 ### Changed
@@ -73,7 +77,8 @@ QA passed
 ### Fixed 
  - no hover effect on `engagement score` rating stars
 
-[Unreleased]: https://github.com/DeskproApps/mailchimp/compare/v0.1.10...HEAD
+[Unreleased]: https://github.com/DeskproApps/mailchimp/compare/v0.1.11...HEAD
+[0.1.11]: https://github.com/DeskproApps/mailchimp/compare/v0.1.10...v0.1.11
 [0.1.10]: https://github.com/DeskproApps/mailchimp/compare/v0.1.9...v0.1.10
 [0.1.9]: https://github.com/DeskproApps/mailchimp/compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com/DeskproApps/mailchimp/compare/v0.1.7...v0.1.8

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskproapps/app-mailchimp",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deskproapps/app-mailchimp",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "This application adds a sidebar that lets you see Mailchimp's rating, campaing and subscription information of a ticket's owner",
   "main": "lib/main/javascript/index.js",
   "scripts": {

--- a/src/webpack/webpack.config-distribution.js
+++ b/src/webpack/webpack.config-distribution.js
@@ -5,6 +5,7 @@ module.exports = function (env) {
 
   const PROJECT_ROOT_PATH = env && env.DP_PROJECT_ROOT ? env.DP_PROJECT_ROOT : path.resolve(__dirname, '../../');
   const DEBUG = env && env.NODE_ENV === 'development';
+  const ENVIRONMENT =  env && env.NODE_ENV ? env.NODE_ENV : 'production';
 
   const buildManifest = new dpat.BuildManifest(
     PROJECT_ROOT_PATH,
@@ -67,7 +68,8 @@ module.exports = function (env) {
 
       new dpat.Webpack.DefinePlugin({
         DEBUG: DEBUG,
-        DPAPP_MANIFEST: JSON.stringify(buildManifest.getContent())
+        DPAPP_MANIFEST: JSON.stringify(buildManifest.getContent()),
+        'process.env.NODE_ENV': JSON.stringify(ENVIRONMENT)
       }),
 
       // for stable builds, in production we replace the default module index with the module's content hashe


### PR DESCRIPTION
 - default `process.env.NODE_ENV` to `production` when packaging the app for distribution with webpack