### PR TITLE
Added  into the manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,8 @@
   "name": "@deskpro-apps/mailchimp",
   "title": "Mailchimp",
   "description": "Link Deskpro user profiles to Mailchimp contacts so agents can see which audiences and campaigns users are subscribed to",
-  "version": "1.0.0",
+  "appStoreUrl": "https://www.deskpro.com/product-embed/apps/mailchimp",
+  "version": "1.0.1",
   "scope": "agent",
   "isSingleInstall": true,
   "targets": [{


### PR DESCRIPTION
Story https://app.shortcut.com/deskpro/story/61817/apps-allow-app-developers-to-showcase-app-screenshots-as-a-carousel-in-deskpro-admin