### PR TITLE
Remove unusued axios dependancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "ts-pattern": "^3.3.5"
   },
   "devDependencies": {
-    "@originjs/vite-plugin-commonjs": "1.0.1",
     "@types/lodash": "^4.17.20",
     "@types/react": "17.0.38",
     "@types/react-dom": "17.0.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,9 +57,6 @@ importers:
         specifier: ^3.3.5
         version: 3.3.5
     devDependencies:
-      '@originjs/vite-plugin-commonjs':
-        specifier: 1.0.1
-        version: 1.0.1
       '@types/lodash':
         specifier: ^4.17.20
         version: 4.17.20
@@ -543,9 +540,6 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
-
-  '@originjs/vite-plugin-commonjs@1.0.1':
-    resolution: {integrity: sha512-7TJFrFxT6UZIn175095vBNSYMtu+8cwgLb+R2AtuRoz/+h8eaa/Fn7D4QtL9fZMRVHJgYxNVW3Ze3FHk9fGGCQ==}
 
   '@parcel/watcher-android-arm64@2.5.1':
     resolution: {integrity: sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==}
@@ -1114,10 +1108,6 @@ packages:
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
-
-  esbuild@0.12.29:
-    resolution: {integrity: sha512-w/XuoBCSwepyiZtIRsKsetiLDUVGPVw1E/R3VTFSecIy8UR7Cq3SOtwKHJMFoVqqVG36aGkzh4e8BvpO1Fdc7g==}
-    hasBin: true
 
   esbuild@0.25.6:
     resolution: {integrity: sha512-GVuzuUwtdsghE3ocJ9Bs8PNoF13HNQ5TXbEi2AhvVb8xU1Iwt9Fos9FEamfoee+u/TOsn7GUWc04lz46n2bbTg==}
@@ -2529,10 +2519,6 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@originjs/vite-plugin-commonjs@1.0.1':
-    dependencies:
-      esbuild: 0.12.29
-
   '@parcel/watcher-android-arm64@2.5.1':
     optional: true
 
@@ -3059,8 +3045,6 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
-
-  esbuild@0.12.29: {}
 
   esbuild@0.25.6:
     optionalDependencies:


### PR DESCRIPTION
This pull request removes unused dependencies from the project, specifically targeting `@originjs/vite-plugin-commonjs` and an older version of `esbuild`. These changes help streamline the dependency tree and reduce potential maintenance overhead.

### Dependency Cleanup:

* Removed `@originjs/vite-plugin-commonjs` from `devDependencies` in `package.json` and all associated references in `pnpm-lock.yaml`. This includes removing its resolution, version specification, and dependency information. (`[[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L34)`, `[[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL60-L62)`, `[[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL547-L549)`, `[[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2532-L2535)`)

* Removed `esbuild@0.12.29` from `pnpm-lock.yaml`, including its resolution and references in the `snapshots` section. The newer version of `esbuild` (`0.25.6`) remains in use. (`[[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1118-L1121)`, `[[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3063-L3064)`)