### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -77,12 +77,21 @@
       {
         "url": "https://(.*).api.mailchimp.com/.*",
         "methods": ["GET", "POST", "PUT", "DELETE"],
-        "timeout": 30
+        "timeout": 30,
+        "settingsInjection": {}
       },
       {
         "url": "https://login.mailchimp.com/oauth2/.*",
         "methods": ["GET", "POST"],
-        "timeout": 30
+        "timeout": 30,
+        "settingsInjection": {
+          "client_id": {
+            "body": ["client_id"]
+          },
+          "client_secret": {
+            "body": ["client_secret"]
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
This pull request introduces an update to the Mailchimp API configuration in the `manifest.json` file. The main change is the addition of a `settingsInjection` property to improve how sensitive settings like OAuth credentials are handled.

Configuration improvements for Mailchimp API:

* Added an empty `settingsInjection` object to the main Mailchimp API endpoint configuration to support future extensibility.
* Added a `settingsInjection` object to the OAuth endpoint configuration, specifying that `client_id` and `client_secret` should be injected into the request body for authentication purposes.